### PR TITLE
Refactor and add support for older installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,15 @@ Bash script to help build and run an offline installer in recovery.
 
 It seems the Sonoma+ BaseSystem.dmg recovery environment does not allow mounting FAT32 or ExFAT volumes at all.  To work around this using UnPlugged requires a couple extra steps.
 
-You'll need to use an earlier BaseSystem.dmg|.chunklist downloaded via `macrecovery.py` in your com.apple.recovery.boot folder (Ventura works fine with FAT32 and ExFAT volumes).  You'll also need to download Sonoma's BaseSystem.dmg via `macrecovery.py` and place that alongside the files downloaded with `gibMacOS` if you don't intend to expand the InstallAsisstant.pkg directly.  The end result should look something like the following:
+You'll need to use an earlier BaseSystem.dmg|.chunklist downloaded via `macrecovery.py` in your com.apple.recovery.boot folder (Monterey works fine with FAT32 and ExFAT volumes).  You'll also need to download Sonoma's BaseSystem.dmg via `macrecovery.py` and place that alongside the files downloaded with `gibMacOS` if you don't intend to expand the InstallAsisstant.pkg directly.  The end result should look something like the following:
 
 ```
 USB Drive
 |-> 800MB FAT32 Partition (named OPENCORE or similar)
 |   |-> EFI
 |   \-> com.apple.recovery.boot
-|       |-> BaseSystem.dmg (for Ventura)
-|       \-> BaseSystem.chunklist (for Ventura)
+|       |-> BaseSystem.dmg (for Monterey)
+|       \-> BaseSystem.chunklist (for Monterey)
 \-> 15+GB ExFAT Partition (named UnPlugged or similar)
     |-> InstallAssistant.pkg (for Sonoma+)
     |-> BaseSystem.dmg (for Sonoma+, if not expanding the .pkg directly)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Bash script to help build and run an offline installer in recovery.
 ## Prerequisites
 
 * [UnPlugged](https://github.com/corpnewt/UnPlugged)
-* [gibMacOS](https://github.com/corpnewt/gibMacOS)
+* [gibMacOS](https://github.com/corpnewt/gibMacOS) - or a .dmg/.pkg from the "older versions" linked [here](https://support.apple.com/en-us/102662)
 * [macrecovery.py](https://github.com/acidanthera/OpenCorePkg/tree/master/Utilities/macrecovery) (or [gibMacRecovery](https://github.com/corpnewt/gibMacRecovery))
 * A 16+ GB USB drive
 * Your EFI set up by following the [Dortania guide](https://dortania.github.io/OpenCore-Install-Guide/)

--- a/UnPlugged.command
+++ b/UnPlugged.command
@@ -387,10 +387,19 @@ function pkgWarn () {
     if [ -z "$pkgname" ]; then
         pkgname="the selected pkg"
     fi
+    name="$(sw_vers -productName)"
+    prod="$(sw_vers -productVersion)"
+    build="$(sw_vers -buildVersion)"
     echo 
     clear 2>/dev/null
-    echo "Could not extract required info from $pkgname."
-    echo "That could indicate that it may be corrupt, or is missing files."
+    echo "!! Could not extract required info from $pkgname !!"
+    echo "!! That could indicate that it may be corrupt, or is missing files !!"
+    echo
+    echo "Some recovery environments have odd issues (Ventura, for instance) which limit"
+    echo "the information pkgutil can obtain.  In those cases, as long as the .pkg copy"
+    echo "process completed correctly, you should be fine continuing."
+    echo
+    echo "Currently running $name $prod ($build)."
     echo
     while true; do
         read -r -p "Do you wish to continue? [y/n]: " yn
@@ -479,7 +488,7 @@ function strEndsWith () {
 
 # Gather some info to figure out how to proceed
 # Let's look for "expand-full" in pkgutil itself
-grep -a expand-full /usr/sbin/pkgutil >/dev/null 2>&1
+cat /usr/sbin/pkgutil | grep -i "expand-full" >/dev/null 2>&1
 [ "$?" == "0" ] && can_expand_full=1 || can_expand_full=0
 findApps
 echo

--- a/UnPlugged.command
+++ b/UnPlugged.command
@@ -395,7 +395,7 @@ function pkgWarn () {
     echo "!! Could not extract required info from $pkgname !!"
     echo "!! That could indicate that it may be corrupt, or is missing files !!"
     echo
-    echo "Some recovery environments have odd issues (Ventura, for instance) which limit"
+    echo "Some recovery environments have odd issues (macOS 13, for instance) which limit"
     echo "the information pkgutil can obtain.  In those cases, as long as the .pkg copy"
     echo "process completed correctly, you should be fine continuing."
     echo
@@ -405,7 +405,7 @@ function pkgWarn () {
         read -r -p "Do you wish to continue? [y/n]: " yn
         case $yn in
             [Yy]* ) break;;
-            [Nn]* ) exit;;
+            [NnQq]* ) exit;;
             * ) echo "Please answer yes or no.";;
         esac
     done
@@ -617,7 +617,7 @@ while true; do
     read -r -p "Do you wish to continue? [y/n]: " yn
     case $yn in
         [Yy]* ) break;;
-        [Nn]* ) exit;;
+        [NnQq]* ) exit;;
         * ) echo "Please answer yes or no.";;
     esac
 done

--- a/UnPlugged.command
+++ b/UnPlugged.command
@@ -702,7 +702,7 @@ else
     done < "$dir/InstallInfo.plist"
 fi
 # Clean up after ourselves if needed
-if [ ! -z "$mount_point" ]; then
+if [ ! -z "$mount_point" ] && [ "$install_type" != "old" ]; then
     echo "- Unmounting $base_system..."
     hdiutil detach "$mount_point" >/dev/null 2>&1
 fi


### PR DESCRIPTION
Adds support for installers hosted by Apple [here](https://support.apple.com/en-us/102662) - as well as some refinements in the general approach.

`pkgutil --expand-full` support detection has changed from using `grep -a` to `cat | grep`, as the former doesn't seem as widely supported and may result in false negatives.

Ventura is no longer recommended as the stand-in recovery env for Sonoma and newer due to some oddities.  Monterey is recommended now.

In the event a pkg file fails verification (via `pkgutil --payload-files`), prompt to see if the user would still like to continue - as some recovery envs are unable to properly use that switch.